### PR TITLE
Update spoiler icon

### DIFF
--- a/lib/src/format_markdown.dart
+++ b/lib/src/format_markdown.dart
@@ -238,7 +238,7 @@ enum MarkdownType {
       case MarkdownType.community:
         return const IconData(0x0021);
       case MarkdownType.spoiler:
-        return Icons.lock_rounded;
+        return Icons.comments_disabled_rounded;
     }
   }
 }


### PR DESCRIPTION
This is a super small PR which updates the spoiler markdown icon from [this](https://api.flutter.dev/flutter/material/Icons/lock_rounded-constant.html) to [this](https://api.flutter.dev/flutter/material/Icons/comments_disabled_rounded-constant.html), which I think looks better!